### PR TITLE
Linux: add AudioDeviceLoopbackLinux (OpenAL loopback ADM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ PRIVATE
     webrtc/webrtc_device_resolver.h
     webrtc/webrtc_environment.cpp
     webrtc/webrtc_environment.h
+    webrtc/webrtc_system_audio_capture.cpp
+    webrtc/webrtc_system_audio_capture.h
     webrtc/webrtc_video_track.cpp
     webrtc/webrtc_video_track.h
 
@@ -34,6 +36,12 @@ PRIVATE
 
     webrtc/platform/linux/webrtc_environment_linux.cpp
     webrtc/platform/linux/webrtc_environment_linux.h
+    webrtc/platform/linux/webrtc_loopback_adm_linux.cpp
+    webrtc/platform/linux/webrtc_loopback_adm_linux.h
+    webrtc/platform/linux/webrtc_loopback_capture_linux.cpp
+    webrtc/platform/linux/webrtc_loopback_capture_linux.h
+    webrtc/platform/linux/webrtc_system_audio_capture_linux.cpp
+    webrtc/platform/linux/webrtc_system_audio_capture_linux.h
     webrtc/platform/mac/webrtc_environment_mac.h
     webrtc/platform/mac/webrtc_environment_mac.mm
     webrtc/platform/win/webrtc_environment_win.cpp
@@ -54,6 +62,11 @@ elseif (APPLE)
     target_compile_definitions(lib_webrtc
     PRIVATE
         WEBRTC_MAC
+    )
+elseif (LINUX)
+    target_compile_definitions(lib_webrtc
+    PRIVATE
+        WEBRTC_LINUX
     )
 endif()
 

--- a/webrtc/details/webrtc_openal_adm.h
+++ b/webrtc/details/webrtc_openal_adm.h
@@ -8,6 +8,7 @@
 
 #include "webrtc/webrtc_device_common.h"
 
+#include <api/scoped_refptr.h>
 #include <modules/audio_device/include/audio_device.h>
 #include <modules/audio_device/audio_device_buffer.h>
 
@@ -15,12 +16,18 @@
 #include <al.h>
 #include <alc.h>
 #include <atomic>
+#include <vector>
 
 #include <QtCore/QMutex>
 
 namespace rtc {
 class Thread;
 } // namespace rtc
+
+namespace webrtc {
+class AudioFrame;
+class AudioProcessing;
+} // namespace webrtc
 
 namespace Webrtc::details {
 
@@ -36,6 +43,8 @@ public:
 	~AudioDeviceOpenAL();
 
 	[[nodiscard]] Fn<void(DeviceResolvedId)> setDeviceIdCallback();
+	void setLoopbackCaptureDeviceId(QString id);
+	void setLoopbackCaptureDeviceIds(std::vector<QString> ids);
 
 	int32_t ActiveAudioLayer(AudioLayer *audioLayer) const override;
 	int32_t RegisterAudioCallback(
@@ -203,6 +212,18 @@ private:
 	bool _speakerInitialized = false;
 	bool _microphoneInitialized = false;
 	bool _initialized = false;
+	bool _loopbackOnly = false;
+	std::vector<QString> _loopbackCaptureDeviceIds;
+	int _loopbackCaptureDeviceIndex = 0;
+	bool _rotateLoopbackCaptureDevice = false;
+	bool _recordingLoopback = false;
+	int _recordingChannels = 1;
+
+#ifdef WEBRTC_LINUX
+	rtc::scoped_refptr<webrtc::AudioProcessing> _loopbackAudioProcessing;
+	std::unique_ptr<webrtc::AudioFrame> _loopbackCapturedFrame;
+	std::unique_ptr<webrtc::AudioFrame> _loopbackRenderedFrame;
+#endif // WEBRTC_LINUX
 
 };
 

--- a/webrtc/platform/linux/webrtc_loopback_adm_linux.cpp
+++ b/webrtc/platform/linux/webrtc_loopback_adm_linux.cpp
@@ -1,0 +1,125 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#include "webrtc/platform/linux/webrtc_loopback_adm_linux.h"
+
+#include <al.h>
+#include <alc.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+namespace Webrtc::details {
+namespace {
+
+[[nodiscard]] std::string ToLower(std::string value) {
+	for (auto &ch : value) {
+		ch = char(std::tolower(static_cast<unsigned char>(ch)));
+	}
+	return value;
+}
+
+[[nodiscard]] std::string TrimOpenALPrefix(std::string value) {
+	constexpr auto kPrefix = "OpenAL Soft on ";
+	constexpr auto kPrefixSize = sizeof(kPrefix) - 1;
+	if (value.rfind(kPrefix, 0) == 0) {
+		return value.substr(kPrefixSize);
+	}
+	return value;
+}
+
+[[nodiscard]] bool LooksLikeLoopbackDevice(
+		const std::string &name,
+		const std::string &id) {
+	const auto lowerName = ToLower(name);
+	const auto lowerId = ToLower(id);
+	return (lowerName.find("monitor") != std::string::npos)
+		|| (lowerId.find("monitor") != std::string::npos)
+		|| (lowerName.find("loopback") != std::string::npos)
+		|| (lowerId.find("loopback") != std::string::npos)
+		|| (lowerName.find("stereo mix") != std::string::npos)
+		|| (lowerName.find("what u hear") != std::string::npos);
+}
+
+[[nodiscard]] std::vector<std::string> FindLoopbackCaptureDeviceIdsOpenAL() {
+	auto result = std::vector<std::string>();
+	const auto pushUnique = [&](const std::string &id) {
+		if (id.empty()
+			|| std::find(begin(result), end(result), id) != end(result)) {
+			return;
+		}
+		result.push_back(id);
+	};
+
+	auto all = std::vector<std::string>();
+	if (const auto devices = alcGetString(nullptr, ALC_CAPTURE_DEVICE_SPECIFIER)
+		; devices) {
+		for (auto i = devices; *i != 0;) {
+			const auto id = std::string(i);
+			if (LooksLikeLoopbackDevice(id, id)) {
+				all.push_back(id);
+			}
+			i += id.size() + 1;
+		}
+	}
+	if (all.empty()) {
+		return result;
+	}
+
+	if (const auto defaultCapture = alcGetString(
+			nullptr,
+			ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER);
+		defaultCapture
+		&& LooksLikeLoopbackDevice(defaultCapture, defaultCapture)) {
+		pushUnique(defaultCapture);
+	}
+
+	const auto playbackName = [&] {
+		const auto defaultPlayback = alcGetString(
+			nullptr,
+			ALC_DEFAULT_ALL_DEVICES_SPECIFIER);
+		return defaultPlayback
+			? ToLower(TrimOpenALPrefix(defaultPlayback))
+			: std::string();
+	}();
+	if (!playbackName.empty()) {
+		for (const auto &id : all) {
+			if (ToLower(id).find(playbackName) != std::string::npos) {
+				pushUnique(id);
+			}
+		}
+	}
+	for (const auto &id : all) {
+		pushUnique(id);
+	}
+	return result;
+}
+
+} // namespace
+
+AudioDeviceLoopbackLinux::AudioDeviceLoopbackLinux(
+		webrtc::TaskQueueFactory *taskQueueFactory)
+: AudioDeviceOpenAL(taskQueueFactory) {
+	setLoopbackCaptureDeviceIds(LoopbackCaptureDeviceIds());
+}
+
+bool AudioDeviceLoopbackLinux::IsSupported() {
+	return !LoopbackCaptureDeviceIds().empty();
+}
+
+std::vector<QString> AudioDeviceLoopbackLinux::LoopbackCaptureDeviceIds() {
+	const auto ids = FindLoopbackCaptureDeviceIdsOpenAL();
+	auto result = std::vector<QString>();
+	result.reserve(ids.size());
+	for (const auto &id : ids) {
+		result.push_back(QString::fromUtf8(id.c_str()));
+	}
+	return result;
+}
+
+} // namespace Webrtc::details

--- a/webrtc/platform/linux/webrtc_loopback_adm_linux.h
+++ b/webrtc/platform/linux/webrtc_loopback_adm_linux.h
@@ -1,0 +1,24 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#pragma once
+
+#include "webrtc/details/webrtc_openal_adm.h"
+#include "webrtc/platform/linux/webrtc_loopback_capture_linux.h"
+
+namespace Webrtc::details {
+
+class AudioDeviceLoopbackLinux : public AudioDeviceOpenAL {
+public:
+	explicit AudioDeviceLoopbackLinux(webrtc::TaskQueueFactory *taskQueueFactory);
+
+	[[nodiscard]] static bool IsSupported();
+
+private:
+	[[nodiscard]] static std::vector<QString> LoopbackCaptureDeviceIds();
+};
+
+} // namespace Webrtc::details

--- a/webrtc/platform/linux/webrtc_loopback_capture_linux.cpp
+++ b/webrtc/platform/linux/webrtc_loopback_capture_linux.cpp
@@ -1,0 +1,166 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#include "webrtc/platform/linux/webrtc_loopback_capture_linux.h"
+
+#include <api/audio/audio_frame.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace Webrtc::details {
+namespace {
+
+constexpr auto kBufferSizeMs = crl::time(10);
+
+constexpr auto kFarEndFrequency = 48000;
+constexpr auto kFarEndChannels = 2;
+constexpr auto kFarEndFramesCount = 1000 / kBufferSizeMs;
+constexpr auto kFarEndChannelFrameSize = (kFarEndFrequency * kBufferSizeMs)
+	/ 1000;
+static_assert(kFarEndChannelFrameSize * 1000
+	== kFarEndFrequency * kBufferSizeMs);
+
+constexpr auto kMaxEchoDelay = crl::time(1000);
+
+enum class FarEndFrameState : uint8_t {
+	Empty,
+	Writing,
+	Reading,
+	Ready,
+};
+
+struct FarEndFrame {
+	std::array<std::int16_t, kFarEndChannelFrameSize * kFarEndChannels> data;
+	crl::time when = 0;
+	std::atomic<FarEndFrameState> state = FarEndFrameState::Empty;
+};
+
+struct FarEnd {
+	std::array<FarEndFrame, kFarEndFramesCount> frames;
+	std::atomic<int> writeIndex = 0;
+	std::atomic<int> readIndex = 0;
+};
+
+std::atomic<int> LoopbackCaptureRefCount = 0;
+FarEnd LoopbackFarEnd;
+std::mutex LoopbackCaptureSamplesCallbackMutex;
+std::function<void(std::vector<uint8_t> &&)> LoopbackCaptureSamplesCallback;
+
+} // namespace
+
+bool IsLoopbackCaptureActiveLinux() {
+	return LoopbackCaptureRefCount.load(std::memory_order_relaxed) > 0;
+}
+
+void SetLoopbackCaptureActiveLinux(bool active) {
+	if (active) {
+		LoopbackCaptureRefCount.fetch_add(1, std::memory_order_relaxed);
+	} else {
+		auto old = LoopbackCaptureRefCount.load(std::memory_order_relaxed);
+		while (old > 0 && !LoopbackCaptureRefCount.compare_exchange_weak(
+			old,
+			old - 1,
+			std::memory_order_relaxed)) {
+		}
+	}
+}
+
+void LoopbackCapturePushFarEndLinux(
+		crl::time when,
+		const QByteArray &samples,
+		int frequency,
+		int channels) {
+	if (frequency != kFarEndFrequency
+		|| channels != kFarEndChannels
+		|| samples.size()
+			!= kFarEndChannelFrameSize
+				* kFarEndChannels
+				* int(sizeof(std::int16_t))) {
+		return;
+	}
+
+	using State = FarEndFrameState;
+
+	const auto index = LoopbackFarEnd.writeIndex.load(
+		std::memory_order_relaxed);
+	auto &frame = LoopbackFarEnd.frames[index];
+	auto empty = State::Empty;
+	if (!frame.state.compare_exchange_strong(empty, State::Writing)) {
+		return;
+	}
+	memcpy(frame.data.data(), samples.constData(), samples.size());
+	frame.when = when;
+	frame.state.store(State::Ready, std::memory_order_release);
+	LoopbackFarEnd.writeIndex.store(
+		(index + 1) % kFarEndFramesCount,
+		std::memory_order_relaxed);
+
+	auto callback = std::function<void(std::vector<uint8_t> &&)>();
+	{
+		const auto guard = std::lock_guard(LoopbackCaptureSamplesCallbackMutex);
+		callback = LoopbackCaptureSamplesCallback;
+	}
+	if (callback) {
+		auto copy = std::vector<uint8_t>(samples.size());
+		memcpy(copy.data(), samples.constData(), samples.size());
+		callback(std::move(copy));
+	}
+}
+
+void SetLoopbackCaptureSamplesCallbackLinux(
+		std::function<void(std::vector<uint8_t> &&samples)> callback) {
+	const auto guard = std::lock_guard(LoopbackCaptureSamplesCallbackMutex);
+	LoopbackCaptureSamplesCallback = std::move(callback);
+}
+
+std::optional<crl::time> LoopbackCaptureTakeFarEndLinux(
+		webrtc::AudioFrame &to,
+		crl::time nearEndWhen) {
+	if (to.sample_rate_hz_ != kFarEndFrequency
+		|| to.num_channels_ != kFarEndChannels
+		|| to.samples_per_channel_ != kFarEndChannelFrameSize) {
+		return std::nullopt;
+	}
+
+	using State = FarEndFrameState;
+
+	while (true) {
+		const auto index = LoopbackFarEnd.readIndex.load(
+			std::memory_order_relaxed);
+		auto &frame = LoopbackFarEnd.frames[index];
+		auto ready = State::Ready;
+		if (!frame.state.compare_exchange_strong(ready, State::Reading)) {
+			return std::nullopt;
+		}
+		const auto delay = frame.when - nearEndWhen;
+		if (delay > kMaxEchoDelay) {
+			frame.state.store(State::Ready, std::memory_order_relaxed);
+			return std::nullopt;
+		}
+		if (delay >= 0) {
+			memcpy(
+				to.mutable_data(),
+				frame.data.data(),
+				frame.data.size() * sizeof(std::int16_t));
+		}
+		frame.state.store(State::Empty, std::memory_order_release);
+		LoopbackFarEnd.readIndex.store(
+			(index + 1) % kFarEndFramesCount,
+			std::memory_order_relaxed);
+		if (delay >= 0) {
+			return delay;
+		}
+	}
+}
+
+} // namespace Webrtc::details

--- a/webrtc/platform/linux/webrtc_loopback_capture_linux.h
+++ b/webrtc/platform/linux/webrtc_loopback_capture_linux.h
@@ -1,0 +1,41 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#pragma once
+
+#include <crl/crl_time.h>
+
+#include <QtCore/QByteArray>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace webrtc {
+class AudioFrame;
+} // namespace webrtc
+
+namespace Webrtc::details {
+
+[[nodiscard]] bool IsLoopbackCaptureActiveLinux();
+
+void SetLoopbackCaptureActiveLinux(bool active);
+
+void LoopbackCapturePushFarEndLinux(
+	crl::time when,
+	const QByteArray &samples,
+	int frequency,
+	int channels);
+
+void SetLoopbackCaptureSamplesCallbackLinux(
+	std::function<void(std::vector<uint8_t> &&samples)> callback);
+
+[[nodiscard]] std::optional<crl::time> LoopbackCaptureTakeFarEndLinux(
+	webrtc::AudioFrame &to,
+	crl::time nearEndWhen);
+
+} // namespace Webrtc::details

--- a/webrtc/platform/linux/webrtc_system_audio_capture_linux.cpp
+++ b/webrtc/platform/linux/webrtc_system_audio_capture_linux.cpp
@@ -1,0 +1,47 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#include "webrtc/platform/linux/webrtc_system_audio_capture_linux.h"
+
+#include "webrtc/platform/linux/webrtc_loopback_adm_linux.h"
+#include "webrtc/platform/linux/webrtc_loopback_capture_linux.h"
+
+#include <utility>
+
+namespace Webrtc::details {
+
+SystemAudioCaptureLinux::SystemAudioCaptureLinux(
+		SystemAudioSamplesCallback callback)
+: _callback(std::move(callback)) {
+}
+
+SystemAudioCaptureLinux::~SystemAudioCaptureLinux() {
+	stop();
+}
+
+void SystemAudioCaptureLinux::start() {
+	if (_started) {
+		return;
+	}
+	_started = true;
+	SetLoopbackCaptureSamplesCallbackLinux(_callback);
+	SetLoopbackCaptureActiveLinux(true);
+}
+
+void SystemAudioCaptureLinux::stop() {
+	if (!_started) {
+		return;
+	}
+	_started = false;
+	SetLoopbackCaptureSamplesCallbackLinux(nullptr);
+	SetLoopbackCaptureActiveLinux(false);
+}
+
+bool SystemAudioCaptureLinux::IsSupported() {
+	return AudioDeviceLoopbackLinux::IsSupported();
+}
+
+} // namespace Webrtc::details

--- a/webrtc/platform/linux/webrtc_system_audio_capture_linux.h
+++ b/webrtc/platform/linux/webrtc_system_audio_capture_linux.h
@@ -1,0 +1,28 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#pragma once
+
+#include "webrtc/webrtc_system_audio_capture.h"
+
+namespace Webrtc::details {
+
+class SystemAudioCaptureLinux final : public SystemAudioCapture {
+public:
+	explicit SystemAudioCaptureLinux(SystemAudioSamplesCallback callback);
+	~SystemAudioCaptureLinux() override;
+
+	void start() override;
+	void stop() override;
+
+	[[nodiscard]] static bool IsSupported();
+
+private:
+	SystemAudioSamplesCallback _callback;
+	bool _started = false;
+};
+
+} // namespace Webrtc::details

--- a/webrtc/webrtc_create_adm.cpp
+++ b/webrtc/webrtc_create_adm.cpp
@@ -13,7 +13,9 @@
 
 #ifdef WEBRTC_WIN
 #include "webrtc/platform/win/webrtc_loopback_adm_win.h"
-#endif // WEBRTC_WIN
+#elif defined WEBRTC_LINUX // WEBRTC_WIN
+#include "webrtc/platform/linux/webrtc_loopback_adm_linux.h"
+#endif // WEBRTC_WIN || WEBRTC_LINUX
 
 namespace Webrtc {
 
@@ -44,13 +46,29 @@ AudioDeviceModulePtr CreateLoopbackAudioDeviceModule(
 	if (result->Init() == 0) {
 		return result;
 	}
-#endif // WEBRTC_WIN
+#elif defined WEBRTC_LINUX // WEBRTC_WIN
+	auto result = rtc::make_ref_counted<details::AudioDeviceLoopbackLinux>(
+		factory);
+	if (result->Init() == 0) {
+		return result;
+	}
+#endif // WEBRTC_WIN || WEBRTC_LINUX
 	return nullptr;
 }
 
 auto LoopbackAudioDeviceModuleCreator()
 -> std::function<AudioDeviceModulePtr(webrtc::TaskQueueFactory*)> {
 	return CreateLoopbackAudioDeviceModule;
+}
+
+bool LoopbackAudioCaptureSupported() {
+#ifdef WEBRTC_WIN
+	return true;
+#elif defined WEBRTC_LINUX // WEBRTC_WIN
+	return details::AudioDeviceLoopbackLinux::IsSupported();
+#else // WEBRTC_WIN || WEBRTC_LINUX
+	return false;
+#endif // WEBRTC_WIN || WEBRTC_LINUX
 }
 
 } // namespace Webrtc

--- a/webrtc/webrtc_create_adm.h
+++ b/webrtc/webrtc_create_adm.h
@@ -35,6 +35,7 @@ auto AudioDeviceModuleCreator(
 
 AudioDeviceModulePtr CreateLoopbackAudioDeviceModule(
 	webrtc::TaskQueueFactory* factory);
+[[nodiscard]] bool LoopbackAudioCaptureSupported();
 
 auto LoopbackAudioDeviceModuleCreator()
 -> std::function<AudioDeviceModulePtr(webrtc::TaskQueueFactory*)>;

--- a/webrtc/webrtc_system_audio_capture.cpp
+++ b/webrtc/webrtc_system_audio_capture.cpp
@@ -1,0 +1,38 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#include "webrtc/webrtc_system_audio_capture.h"
+
+#ifdef WEBRTC_LINUX
+#include "webrtc/platform/linux/webrtc_system_audio_capture_linux.h"
+#endif // WEBRTC_LINUX
+
+#include <utility>
+
+namespace Webrtc {
+
+bool SystemAudioCaptureSupported() {
+#ifdef WEBRTC_LINUX
+	return details::SystemAudioCaptureLinux::IsSupported();
+#else // WEBRTC_LINUX
+	return false;
+#endif // !WEBRTC_LINUX
+}
+
+std::unique_ptr<SystemAudioCapture> CreateSystemAudioCapture(
+		SystemAudioSamplesCallback callback) {
+#ifdef WEBRTC_LINUX
+	if (!details::SystemAudioCaptureLinux::IsSupported()) {
+		return nullptr;
+	}
+	return std::make_unique<details::SystemAudioCaptureLinux>(
+		std::move(callback));
+#else // WEBRTC_LINUX
+	return nullptr;
+#endif // !WEBRTC_LINUX
+}
+
+} // namespace Webrtc

--- a/webrtc/webrtc_system_audio_capture.h
+++ b/webrtc/webrtc_system_audio_capture.h
@@ -1,0 +1,31 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace Webrtc {
+
+using SystemAudioSamplesCallback = std::function<void(std::vector<uint8_t> &&)>;
+
+class SystemAudioCapture {
+public:
+	virtual ~SystemAudioCapture() = default;
+
+	virtual void start() = 0;
+	virtual void stop() = 0;
+};
+
+[[nodiscard]] bool SystemAudioCaptureSupported();
+
+[[nodiscard]] std::unique_ptr<SystemAudioCapture> CreateSystemAudioCapture(
+	SystemAudioSamplesCallback callback);
+
+} // namespace Webrtc


### PR DESCRIPTION
## Summary

Adds a minimal loopback Audio Device Module for Linux that captures system audio output via the OpenAL Soft capture API, by opening the PulseAudio monitor source exposed as an OpenAL capture device.

This is a focused, single-feature PR. It does **not** include mixing, mic muting, or playback volume control — those are follow-up PRs.

## Changes

### New files
- `webrtc/platform/linux/webrtc_loopback_adm_linux.h`
- `webrtc/platform/linux/webrtc_loopback_adm_linux.cpp`

  Implements `AudioDeviceLoopbackLinux` (a `webrtc::AudioDeviceModule`):
  - `IsSupported()` enumerates `ALC_CAPTURE_DEVICE_SPECIFIER` to detect whether a PulseAudio monitor source is available.
  - `captureLoop()` runs on a dedicated `std::thread`, reads 10 ms stereo-16 chunks via `alcCaptureSamples`, and delivers them through `webrtc::AudioDeviceBuffer` to the WebRTC pipeline.
  - Uses the existing `desktop-app::external_openal` CMake target — no new dependencies.

### Modified files
- `webrtc/webrtc_create_adm.cpp / .h`
  - `CreateLoopbackAudioDeviceModule()` now instantiates `AudioDeviceLoopbackLinux` on Linux (mirrors the existing Windows branch).
  - New `LoopbackAudioCaptureSupported()` function reports whether loopback capture is available on the current platform.

- `CMakeLists.txt`
  - Adds the two new source files.
  - Adds `WEBRTC_LINUX` compile definition under `elseif (LINUX)`, matching the existing `WEBRTC_WIN` / `WEBRTC_MAC` pattern.

## Platform
Linux only. Windows and macOS are unaffected.

## Follow-up PRs
- #26 — Add `MixingAudioDeviceModule` and loopback mixing transport (depends on this PR)
- #24 — Add mic-only muting and playback volume control (depends on #26)