### PR TITLE
Linux: add AudioDeviceLoopbackLinux (OpenAL loopback ADM)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ PRIVATE
 
     webrtc/platform/linux/webrtc_environment_linux.cpp
     webrtc/platform/linux/webrtc_environment_linux.h
+    webrtc/platform/linux/webrtc_loopback_adm_linux.cpp
+    webrtc/platform/linux/webrtc_loopback_adm_linux.h
     webrtc/platform/mac/webrtc_environment_mac.h
     webrtc/platform/mac/webrtc_environment_mac.mm
     webrtc/platform/win/webrtc_environment_win.cpp
@@ -54,6 +56,11 @@ elseif (APPLE)
     target_compile_definitions(lib_webrtc
     PRIVATE
         WEBRTC_MAC
+    )
+elseif (LINUX)
+    target_compile_definitions(lib_webrtc
+    PRIVATE
+        WEBRTC_LINUX
     )
 endif()
 

--- a/webrtc/platform/linux/webrtc_loopback_adm_linux.cpp
+++ b/webrtc/platform/linux/webrtc_loopback_adm_linux.cpp
@@ -1,0 +1,455 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#include "webrtc/platform/linux/webrtc_loopback_adm_linux.h"
+
+#include <al.h>
+#include <alc.h>
+
+#include <rtc_base/logging.h>
+
+#include <chrono>
+#include <cstring>
+#include <vector>
+
+namespace Webrtc::details {
+namespace {
+
+constexpr auto kSampleRate = 48000;
+constexpr auto kChannels = 2;
+constexpr auto kBufferSizeMs = 10;
+constexpr auto kFramesPerChunk = (kSampleRate * kBufferSizeMs) / 1000; // 480
+constexpr auto kCaptureBufferFrames = kFramesPerChunk * 4; // 40ms ring buffer
+constexpr ALenum kCaptureFormat = AL_FORMAT_STEREO16;
+
+} // namespace
+
+AudioDeviceLoopbackLinux::AudioDeviceLoopbackLinux(
+	webrtc::TaskQueueFactory *taskQueueFactory)
+: _audioDeviceBuffer(taskQueueFactory) {
+}
+
+AudioDeviceLoopbackLinux::~AudioDeviceLoopbackLinux() {
+	Terminate();
+}
+
+// static
+bool AudioDeviceLoopbackLinux::IsSupported() {
+	return !FindMonitorDevice().empty();
+}
+
+// static
+std::string AudioDeviceLoopbackLinux::FindMonitorDevice() {
+	// ALC_CAPTURE_DEVICE_SPECIFIER returns a double-null-terminated list
+	// of device name strings when queried against nullptr.
+	const auto *deviceList = alcGetString(nullptr, ALC_CAPTURE_DEVICE_SPECIFIER);
+	if (!deviceList) {
+		return {};
+	}
+
+	while (*deviceList) {
+		const auto name = std::string(deviceList);
+		// PulseAudio monitor sources contain "monitor" in their OpenAL name.
+		if (name.find("monitor") != std::string::npos
+				|| name.find("Monitor") != std::string::npos) {
+			return name;
+		}
+		deviceList += name.size() + 1;
+	}
+	return {};
+}
+
+int32_t AudioDeviceLoopbackLinux::ActiveAudioLayer(
+		AudioLayer *audioLayer) const {
+	*audioLayer = AudioDeviceModule::kPlatformDefaultAudio;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::RegisterAudioCallback(
+		webrtc::AudioTransport *audioCallback) {
+	return _audioDeviceBuffer.RegisterAudioCallback(audioCallback);
+}
+
+int32_t AudioDeviceLoopbackLinux::Init() {
+	if (_initialized) {
+		return 0;
+	}
+	_captureDeviceId = FindMonitorDevice();
+	if (_captureDeviceId.empty()) {
+		RTC_LOG(LS_ERROR)
+			<< "AudioDeviceLoopbackLinux::Init: "
+			<< "no OpenAL monitor capture device found.";
+		return -1;
+	}
+	_audioDeviceBuffer.SetRecordingSampleRate(kSampleRate);
+	_audioDeviceBuffer.SetRecordingChannels(kChannels);
+	_initialized = true;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::Terminate() {
+	if (!_initialized) {
+		return 0;
+	}
+	StopRecording();
+	_initialized = false;
+	_recordingInitialized = false;
+	_microphoneInitialized = false;
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::Initialized() const {
+	return _initialized;
+}
+
+int16_t AudioDeviceLoopbackLinux::PlayoutDevices() {
+	return 0;
+}
+
+int16_t AudioDeviceLoopbackLinux::RecordingDevices() {
+	return 1;
+}
+
+int32_t AudioDeviceLoopbackLinux::PlayoutDeviceName(
+		uint16_t index,
+		char name[webrtc::kAdmMaxDeviceNameSize],
+		char guid[webrtc::kAdmMaxGuidSize]) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::RecordingDeviceName(
+		uint16_t index,
+		char name[webrtc::kAdmMaxDeviceNameSize],
+		char guid[webrtc::kAdmMaxGuidSize]) {
+	if (index != 0) {
+		return -1;
+	}
+	const auto length = std::min(
+		_captureDeviceId.size(),
+		std::size_t(webrtc::kAdmMaxDeviceNameSize - 1));
+	std::memcpy(name, _captureDeviceId.data(), length);
+	name[length] = '\0';
+	if (guid) {
+		guid[0] = '\0';
+	}
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetPlayoutDevice(uint16_t index) {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetPlayoutDevice(
+		WindowsDeviceType device) {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetRecordingDevice(uint16_t index) {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetRecordingDevice(
+		WindowsDeviceType device) {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::PlayoutIsAvailable(bool *available) {
+	*available = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::InitPlayout() {
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::PlayoutIsInitialized() const {
+	return false;
+}
+
+int32_t AudioDeviceLoopbackLinux::RecordingIsAvailable(bool *available) {
+	*available = _initialized;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::InitRecording() {
+	if (!_initialized) {
+		return -1;
+	}
+	if (_recordingInitialized) {
+		return 0;
+	}
+	_recordingInitialized = true;
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::RecordingIsInitialized() const {
+	return _recordingInitialized;
+}
+
+int32_t AudioDeviceLoopbackLinux::StartPlayout() {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::StopPlayout() {
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::Playing() const {
+	return false;
+}
+
+int32_t AudioDeviceLoopbackLinux::StartRecording() {
+	if (!_recordingInitialized) {
+		return -1;
+	}
+	if (_recording) {
+		return 0;
+	}
+	_shouldStop.store(false);
+	_audioDeviceBuffer.StartRecording();
+	_captureThread = std::thread(&AudioDeviceLoopbackLinux::captureLoop, this);
+	_recording = true;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::StopRecording() {
+	if (!_recording) {
+		return 0;
+	}
+	_shouldStop.store(true);
+	if (_captureThread.joinable()) {
+		_captureThread.join();
+	}
+	_audioDeviceBuffer.StopRecording();
+	_recording = false;
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::Recording() const {
+	return _recording;
+}
+
+int32_t AudioDeviceLoopbackLinux::InitSpeaker() {
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::SpeakerIsInitialized() const {
+	return false;
+}
+
+int32_t AudioDeviceLoopbackLinux::InitMicrophone() {
+	if (!_initialized) {
+		return -1;
+	}
+	_microphoneInitialized = true;
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::MicrophoneIsInitialized() const {
+	return _microphoneInitialized;
+}
+
+int32_t AudioDeviceLoopbackLinux::SpeakerVolumeIsAvailable(bool *available) {
+	*available = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetSpeakerVolume(uint32_t volume) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::SpeakerVolume(uint32_t *volume) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MaxSpeakerVolume(
+		uint32_t *maxVolume) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MinSpeakerVolume(
+		uint32_t *minVolume) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MicrophoneVolumeIsAvailable(
+		bool *available) {
+	*available = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetMicrophoneVolume(uint32_t volume) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MicrophoneVolume(
+		uint32_t *volume) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MaxMicrophoneVolume(
+		uint32_t *maxVolume) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MinMicrophoneVolume(
+		uint32_t *minVolume) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MicrophoneMuteIsAvailable(
+		bool *available) {
+	*available = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetMicrophoneMute(bool enable) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::MicrophoneMute(bool *enabled) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::SpeakerMuteIsAvailable(bool *available) {
+	*available = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetSpeakerMute(bool enable) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::SpeakerMute(bool *enabled) const {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::StereoPlayoutIsAvailable(
+		bool *available) const {
+	*available = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetStereoPlayout(bool enable) {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::StereoPlayout(bool *enabled) const {
+	*enabled = false;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::StereoRecordingIsAvailable(
+		bool *available) const {
+	*available = true;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::SetStereoRecording(bool enable) {
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::StereoRecording(bool *enabled) const {
+	*enabled = true;
+	return 0;
+}
+
+int32_t AudioDeviceLoopbackLinux::PlayoutDelay(uint16_t *delayMS) const {
+	*delayMS = 0;
+	return 0;
+}
+
+bool AudioDeviceLoopbackLinux::BuiltInAECIsAvailable() const {
+	return false;
+}
+
+bool AudioDeviceLoopbackLinux::BuiltInAGCIsAvailable() const {
+	return false;
+}
+
+bool AudioDeviceLoopbackLinux::BuiltInNSIsAvailable() const {
+	return false;
+}
+
+int32_t AudioDeviceLoopbackLinux::EnableBuiltInAEC(bool enable) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::EnableBuiltInAGC(bool enable) {
+	return -1;
+}
+
+int32_t AudioDeviceLoopbackLinux::EnableBuiltInNS(bool enable) {
+	return -1;
+}
+
+void AudioDeviceLoopbackLinux::captureLoop() {
+	ALCdevice *device = alcCaptureOpenDevice(
+		_captureDeviceId.c_str(),
+		kSampleRate,
+		kCaptureFormat,
+		kCaptureBufferFrames);
+	if (!device) {
+		RTC_LOG(LS_ERROR)
+			<< "AudioDeviceLoopbackLinux::captureLoop: "
+			<< "alcCaptureOpenDevice failed for '"
+			<< _captureDeviceId
+			<< "'";
+		return;
+	}
+
+	alcCaptureStart(device);
+	if (alcGetError(device) != ALC_NO_ERROR) {
+		RTC_LOG(LS_ERROR)
+			<< "AudioDeviceLoopbackLinux::captureLoop: "
+			<< "alcCaptureStart failed.";
+		alcCaptureCloseDevice(device);
+		return;
+	}
+
+	// Interleaved stereo int16 samples: kFramesPerChunk frames * kChannels
+	auto buffer = std::vector<int16_t>(kFramesPerChunk * kChannels);
+
+	while (!_shouldStop.load(std::memory_order_acquire)) {
+		auto available = ALCint(0);
+		alcGetIntegerv(device, ALC_CAPTURE_SAMPLES, 1, &available);
+
+		if (alcGetError(device) != ALC_NO_ERROR) {
+			RTC_LOG(LS_ERROR)
+				<< "AudioDeviceLoopbackLinux::captureLoop: "
+				<< "alcGetIntegerv(ALC_CAPTURE_SAMPLES) failed, stopping.";
+			break;
+		}
+
+		if (available < ALCint(kFramesPerChunk)) {
+			// Not enough data for a full 10 ms chunk yet; yield briefly.
+			std::this_thread::sleep_for(std::chrono::milliseconds(5));
+			continue;
+		}
+
+		alcCaptureSamples(
+			device,
+			reinterpret_cast<ALCvoid *>(buffer.data()),
+			kFramesPerChunk);
+		if (alcGetError(device) != ALC_NO_ERROR) {
+			RTC_LOG(LS_ERROR)
+				<< "AudioDeviceLoopbackLinux::captureLoop: "
+				<< "alcCaptureSamples failed, stopping.";
+			break;
+		}
+
+		// Deliver one 10 ms frame to the WebRTC pipeline.
+		// SetRecordedBuffer expects the sample count per channel.
+		_audioDeviceBuffer.SetRecordedBuffer(buffer.data(), kFramesPerChunk);
+		_audioDeviceBuffer.SetVQEData(0, 0);
+		_audioDeviceBuffer.DeliverRecordedData();
+	}
+
+	alcCaptureStop(device);
+	alcCaptureCloseDevice(device);
+}
+
+} // namespace Webrtc::details

--- a/webrtc/platform/linux/webrtc_loopback_adm_linux.h
+++ b/webrtc/platform/linux/webrtc_loopback_adm_linux.h
@@ -1,0 +1,132 @@
+// This file is part of Desktop App Toolkit,
+// a set of libraries for developing nice desktop applications.
+//
+// For license and copyright information please follow this link:
+// https://github.com/desktop-app/legal/blob/master/LEGAL
+//
+#pragma once
+
+#include <modules/audio_device/include/audio_device.h>
+#include <modules/audio_device/audio_device_buffer.h>
+
+#include <atomic>
+#include <string>
+#include <thread>
+
+namespace Webrtc::details {
+
+class AudioDeviceLoopbackLinux : public webrtc::AudioDeviceModule {
+public:
+	explicit AudioDeviceLoopbackLinux(webrtc::TaskQueueFactory *taskQueueFactory);
+	~AudioDeviceLoopbackLinux();
+
+	[[nodiscard]] static bool IsSupported();
+
+	int32_t ActiveAudioLayer(AudioLayer *audioLayer) const override;
+	int32_t RegisterAudioCallback(
+		webrtc::AudioTransport *audioCallback) override;
+
+	// Main initialization and termination
+	int32_t Init() override;
+	int32_t Terminate() override;
+	bool Initialized() const override;
+
+	// Device enumeration
+	int16_t PlayoutDevices() override;
+	int16_t RecordingDevices() override;
+	int32_t PlayoutDeviceName(uint16_t index,
+		char name[webrtc::kAdmMaxDeviceNameSize],
+		char guid[webrtc::kAdmMaxGuidSize]) override;
+	int32_t RecordingDeviceName(uint16_t index,
+		char name[webrtc::kAdmMaxDeviceNameSize],
+		char guid[webrtc::kAdmMaxGuidSize]) override;
+
+	// Device selection
+	int32_t SetPlayoutDevice(uint16_t index) override;
+	int32_t SetPlayoutDevice(WindowsDeviceType device) override;
+	int32_t SetRecordingDevice(uint16_t index) override;
+	int32_t SetRecordingDevice(WindowsDeviceType device) override;
+
+	// Audio transport initialization
+	int32_t PlayoutIsAvailable(bool *available) override;
+	int32_t InitPlayout() override;
+	bool PlayoutIsInitialized() const override;
+	int32_t RecordingIsAvailable(bool *available) override;
+	int32_t InitRecording() override;
+	bool RecordingIsInitialized() const override;
+
+	// Audio transport control
+	int32_t StartPlayout() override;
+	int32_t StopPlayout() override;
+	bool Playing() const override;
+	int32_t StartRecording() override;
+	int32_t StopRecording() override;
+	bool Recording() const override;
+
+	// Audio mixer initialization
+	int32_t InitSpeaker() override;
+	bool SpeakerIsInitialized() const override;
+	int32_t InitMicrophone() override;
+	bool MicrophoneIsInitialized() const override;
+
+	// Speaker volume controls
+	int32_t SpeakerVolumeIsAvailable(bool *available) override;
+	int32_t SetSpeakerVolume(uint32_t volume) override;
+	int32_t SpeakerVolume(uint32_t *volume) const override;
+	int32_t MaxSpeakerVolume(uint32_t *maxVolume) const override;
+	int32_t MinSpeakerVolume(uint32_t *minVolume) const override;
+
+	// Microphone volume controls
+	int32_t MicrophoneVolumeIsAvailable(bool *available) override;
+	int32_t SetMicrophoneVolume(uint32_t volume) override;
+	int32_t MicrophoneVolume(uint32_t *volume) const override;
+	int32_t MaxMicrophoneVolume(uint32_t *maxVolume) const override;
+	int32_t MinMicrophoneVolume(uint32_t *minVolume) const override;
+
+	// Microphone mute control
+	int32_t MicrophoneMuteIsAvailable(bool *available) override;
+	int32_t SetMicrophoneMute(bool enable) override;
+	int32_t MicrophoneMute(bool *enabled) const override;
+
+	// Speaker mute control
+	int32_t SpeakerMuteIsAvailable(bool *available) override;
+	int32_t SetSpeakerMute(bool enable) override;
+	int32_t SpeakerMute(bool *enabled) const override;
+
+	// Stereo support
+	int32_t StereoPlayoutIsAvailable(bool *available) const override;
+	int32_t SetStereoPlayout(bool enable) override;
+	int32_t StereoPlayout(bool *enabled) const override;
+	int32_t StereoRecordingIsAvailable(bool *available) const override;
+	int32_t SetStereoRecording(bool enable) override;
+	int32_t StereoRecording(bool *enabled) const override;
+
+	// Delay information and control
+	int32_t PlayoutDelay(uint16_t *delayMS) const override;
+
+	// Only supported on Android.
+	bool BuiltInAECIsAvailable() const override;
+	bool BuiltInAGCIsAvailable() const override;
+	bool BuiltInNSIsAvailable() const override;
+
+	// Enables the built-in audio effects. Only supported on Android.
+	int32_t EnableBuiltInAEC(bool enable) override;
+	int32_t EnableBuiltInAGC(bool enable) override;
+	int32_t EnableBuiltInNS(bool enable) override;
+
+private:
+	[[nodiscard]] static std::string FindMonitorDevice();
+	void captureLoop();
+
+	webrtc::AudioDeviceBuffer _audioDeviceBuffer;
+	std::string _captureDeviceId;
+	std::thread _captureThread;
+	std::atomic<bool> _shouldStop = false;
+	int _captureChannels = 2;
+	bool _initialized = false;
+	bool _microphoneInitialized = false;
+	bool _recordingInitialized = false;
+	bool _recording = false;
+};
+
+} // namespace Webrtc::details

--- a/webrtc/webrtc_create_adm.cpp
+++ b/webrtc/webrtc_create_adm.cpp
@@ -13,7 +13,9 @@
 
 #ifdef WEBRTC_WIN
 #include "webrtc/platform/win/webrtc_loopback_adm_win.h"
-#endif // WEBRTC_WIN
+#elif defined WEBRTC_LINUX // WEBRTC_WIN
+#include "webrtc/platform/linux/webrtc_loopback_adm_linux.h"
+#endif // WEBRTC_WIN || WEBRTC_LINUX
 
 namespace Webrtc {
 
@@ -44,13 +46,29 @@ AudioDeviceModulePtr CreateLoopbackAudioDeviceModule(
 	if (result->Init() == 0) {
 		return result;
 	}
-#endif // WEBRTC_WIN
+#elif defined WEBRTC_LINUX // WEBRTC_WIN
+	auto result = rtc::make_ref_counted<details::AudioDeviceLoopbackLinux>(
+		factory);
+	if (result->Init() == 0) {
+		return result;
+	}
+#endif // WEBRTC_WIN || WEBRTC_LINUX
 	return nullptr;
 }
 
 auto LoopbackAudioDeviceModuleCreator()
 -> std::function<AudioDeviceModulePtr(webrtc::TaskQueueFactory*)> {
 	return CreateLoopbackAudioDeviceModule;
+}
+
+bool LoopbackAudioCaptureSupported() {
+#ifdef WEBRTC_WIN
+	return true;
+#elif defined WEBRTC_LINUX // WEBRTC_WIN
+	return details::AudioDeviceLoopbackLinux::IsSupported();
+#else // WEBRTC_WIN || WEBRTC_LINUX
+	return false;
+#endif // WEBRTC_WIN || WEBRTC_LINUX
 }
 
 } // namespace Webrtc

--- a/webrtc/webrtc_create_adm.h
+++ b/webrtc/webrtc_create_adm.h
@@ -35,6 +35,7 @@ auto AudioDeviceModuleCreator(
 
 AudioDeviceModulePtr CreateLoopbackAudioDeviceModule(
 	webrtc::TaskQueueFactory* factory);
+[[nodiscard]] bool LoopbackAudioCaptureSupported();
 
 auto LoopbackAudioDeviceModuleCreator()
 -> std::function<AudioDeviceModulePtr(webrtc::TaskQueueFactory*)>;


### PR DESCRIPTION
## Summary

Adds a minimal loopback Audio Device Module for Linux that captures system audio output via the OpenAL Soft capture API, by opening the PulseAudio monitor source exposed as an OpenAL capture device.

This is a focused, self-contained PR. It does **not** include mixing, mic muting, or playback volume control — those are follow-up PRs.

## Changes

### New files
- `webrtc/platform/linux/webrtc_loopback_adm_linux.h`
- `webrtc/platform/linux/webrtc_loopback_adm_linux.cpp`

  Implements `AudioDeviceLoopbackLinux` (a `webrtc::AudioDeviceModule`):
  - `IsSupported()` enumerates `ALC_CAPTURE_DEVICE_SPECIFIER` to detect whether a PulseAudio monitor source is available.
  - `captureLoop()` runs on a dedicated `std::thread`, reads 10 ms stereo-16 chunks via `alcCaptureSamples`, and delivers them through `webrtc::AudioDeviceBuffer` to the WebRTC pipeline.
  - Uses the existing `desktop-app::external_openal` CMake target — no new dependencies.

### Modified files
- `webrtc/webrtc_create_adm.cpp / .h`
  - `CreateLoopbackAudioDeviceModule()` now instantiates `AudioDeviceLoopbackLinux` on Linux (mirrors the existing Windows branch).
  - New `LoopbackAudioCaptureSupported()` function reports whether loopback capture is available on the current platform.

- `CMakeLists.txt`
  - Adds the two new source files.
  - Adds `WEBRTC_LINUX` compile definition under `elseif (LINUX)`, matching the existing `WEBRTC_WIN` / `WEBRTC_MAC` pattern.

## Platform
Linux only. Windows and macOS are unaffected.

## Follow-up PRs
- #26 — Add `MixingAudioDeviceModule` and loopback mixing transport (depends on this PR)
- #24 — Add mic-only muting and playback volume control (depends on #26)